### PR TITLE
docs: zero-to-hero README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,100 @@
-# HiveMind - Matrix bridge
+# HiveMind Matrix Bridge
 
-![imagem](https://github.com/JarbasHiveMind/HiveMind-matrix-bridge/assets/33701864/f70c7889-43eb-41b1-b295-d4d5040ab610)
+Relay a [Matrix](https://matrix.org) chatroom to a [HiveMind](https://github.com/JarbasHiveMind/HiveMind-core) hub.
 
-## Usage
-
-set hivemind credentials in identity file
+The bridge is a HiveMind **satellite** whose input and output are a Matrix room instead of a microphone. Messages that mention the bot are forwarded to the hub as utterances; the hub's spoken reply is posted back into the room. This turns any HiveMind hub (and the OVOS skills behind it) into a Matrix chatbot.
 
 ```
-Usage: HiveMind-matrix run [OPTIONS]
+Matrix room  ⇄  HiveMind-matrix-bridge  ⇄  HiveMind hub (hivemind-core)  ⇄  OVOS skills
+```
 
-  connect a matrix chatroom to hivemind
+## Prerequisites
 
-Options:
-  --botname TEXT      thehivebot
-  --matrixtoken TEXT  syt_dGhl.....
-  --matrixhost TEXT   https://matrix.org
-  --room TEXT         #hivemind-bots:matrix.org
-  --help              Show this message and exit.
+- A running **HiveMind hub** ([hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core)) you can reach over the network.
+- A **HiveMind access key + password** for this bridge, issued by the hub with `hivemind-core add-client` (see [Quickstart](#quickstart)).
+- A **Matrix account** for the bot and an **access token** for it. Any homeserver works (`matrix.org` or self-hosted). Create the account, log in once, and copy its access token (in Element: *Settings → Help & About → Access Token*).
+- The room alias the bot should join (for example `#hivemind-bots:matrix.org`); invite the bot account to that room.
+
+## Install
+
+```bash
+pip install git+https://github.com/JarbasHiveMind/HiveMind-matrix-bridge
+```
+
+Or from a checkout:
+
+```bash
+git clone https://github.com/JarbasHiveMind/HiveMind-matrix-bridge
+cd HiveMind-matrix-bridge
+pip install .
+```
+
+This installs the `HiveMind-matrix` console command.
+
+## Quickstart
+
+**1. Register the bridge on the hub** (run where `hivemind-core` is installed):
+
+```bash
+hivemind-core add-client --name matrix-bridge \
+  --access-key "your-access-key" --password "your-password"
+```
+
+Note the access key and password — the bridge needs them to authenticate.
+
+**2. Store the HiveMind credentials** so they are read automatically:
+
+```bash
+hivemind-client set-identity \
+  --key "your-access-key" \
+  --password "your-password" \
+  --host "ws://192.168.1.100"
+```
+
+(`set-identity` ships with `hivemind-bus-client`, a dependency of this bridge.) Alternatively, pass `--key/--password/--host` on every run instead of storing an identity.
+
+**3. Run the bridge:**
+
+```bash
+HiveMind-matrix run \
+  --botname thehivebot \
+  --matrixtoken "syt_your_access_token" \
+  --matrixhost "https://matrix.org" \
+  --room "#hivemind-bots:matrix.org"
+```
+
+**4. Send a message.** In the joined room, mention the bot:
 
 ```
+thehivebot what time is it?
+```
+
+The bridge strips the mention, forwards `what time is it?` to the hub, waits for the hub's `speak` reply, and posts it back to the room.
+
+## Configuration
+
+`HiveMind-matrix run` options:
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--botname` | Mention prefix that triggers the bot | — |
+| `--matrixtoken` | Matrix access token for the bot account | — |
+| `--matrixhost` | Matrix homeserver URL | `https://matrix.org` |
+| `--room` | Room alias to join | `#hivemind-bots:matrix.org` |
+| `--key` | HiveMind access key | read from identity file |
+| `--password` | HiveMind password | read from identity file |
+| `--host` | HiveMind host (a `ws://` prefix is added if no scheme) | read from identity file |
+| `--port` | HiveMind port | `5678` |
+
+When `--key/--password/--host` are omitted they are read from the stored `NodeIdentity`. If none of the three are available the bridge exits with an error pointing you at `hivemind-client set-identity`.
+
+## Troubleshooting
+
+- **`NodeIdentity not set`** — run `hivemind-client set-identity`, or pass `--key/--password/--host` explicitly.
+- **Bot ignores messages** — the message must contain `--botname` exactly; messages without the mention are dropped by design.
+- **Reply is the literal text `Error`** — the hub did not return a `speak` within the response timeout (30s). Confirm the hub is reachable, the access key is authorized, and an OVOS pipeline is producing spoken answers.
+- **Connection refused / no reply** — verify `--host` and `--port` point at the running hub, and that the bridge's access key is registered (`hivemind-core list-clients`).
+
+## Documentation
+
+See [`docs/`](docs/) for a full setup walkthrough, a credential reference, and worked examples.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,48 @@
+# Configuration & Credentials Reference
+
+The bridge needs two sets of credentials: one for Matrix, one for the HiveMind hub.
+
+## Matrix credentials
+
+| Option | Meaning |
+| --- | --- |
+| `--matrixhost` | Homeserver base URL, for example `https://matrix.org`. Default `https://matrix.org`. |
+| `--matrixtoken` | Access token for the bot account. Obtain it from a logged-in Matrix client. |
+| `--room` | Alias of the room to join, for example `#hivemind-bots:matrix.org`. The bot account must be a member. |
+| `--botname` | Mention prefix that triggers the bot. Only messages containing this string are processed. |
+
+The bot strips the mention before sending the rest of the message to the hub. It recognizes the forms `@botname`, `botname:`, and bare `botname`.
+
+## HiveMind credentials
+
+| Option | Meaning | Default |
+| --- | --- | --- |
+| `--key` | HiveMind access key, from `hivemind-core add-client`. | read from identity file |
+| `--password` | HiveMind password, from `hivemind-core add-client`. | read from identity file |
+| `--host` | Hub host. A `ws://` prefix is added automatically if you omit the scheme. | read from identity file |
+| `--port` | Hub port. | `5678` |
+
+### Identity file
+
+When `--key/--password/--host` are not passed, the bridge reads them from the stored `NodeIdentity`. Set it once with:
+
+```bash
+hivemind-client set-identity \
+  --key "your-access-key" \
+  --password "your-password" \
+  --host "ws://192.168.1.100"
+```
+
+If neither the options nor a stored identity supply a key, password, and host, the bridge raises:
+
+```
+NodeIdentity not set, please pass key/password/host or call 'hivemind-client set-identity'
+```
+
+## Response timeout
+
+The bridge waits up to 30 seconds for the hub's `speak` reply. On timeout it posts the literal text `Error` to the room. The timeout is a constructor argument (`response_timeout`) on `HiveMindMatrixBridge` for programmatic use.
+
+## Encryption
+
+The HiveMind connection is authenticated and encrypted by the protocol layer (handled by `hivemind-bus-client`). The Matrix connection uses the homeserver's HTTPS endpoint. End-to-end encrypted Matrix rooms are not supported by the underlying client library; use an unencrypted room.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,74 @@
+# Examples
+
+## Run with stored identity
+
+Store the HiveMind identity once, then run with only Matrix options:
+
+```bash
+hivemind-client set-identity --key KEY --password PASS --host ws://192.168.1.100
+HiveMind-matrix run \
+  --botname thehivebot \
+  --matrixtoken "syt_..." \
+  --room "#hivemind-bots:matrix.org"
+```
+
+## Run with all credentials inline
+
+Useful for containers or one-off runs where no identity file exists:
+
+```bash
+HiveMind-matrix run \
+  --botname thehivebot \
+  --matrixtoken "syt_..." \
+  --matrixhost "https://matrix.org" \
+  --room "#hivemind-bots:matrix.org" \
+  --key "your-access-key" \
+  --password "your-password" \
+  --host "192.168.1.100" \
+  --port 5678
+```
+
+A `ws://` prefix is added to `--host` automatically when no scheme is given.
+
+## A conversation
+
+Once running, anyone in the room invokes the bot by mentioning it:
+
+```
+alice> thehivebot what time is it?
+thehivebot> It is half past three.
+
+alice> thehivebot set a timer for five minutes
+thehivebot> Timer set for five minutes.
+```
+
+Messages that do not mention `thehivebot` are ignored.
+
+## Embed the bridge in your own program
+
+`HiveMindMatrixBridge` is an asyncio object. The hub and Matrix clients can be injected for testing or customization:
+
+```python
+import asyncio
+from hm_matrix_bridge import HiveMindMatrixBridge
+
+async def main():
+    bridge = HiveMindMatrixBridge(
+        matrix_host="https://matrix.org",
+        matrix_token="syt_...",
+        room_alias="#hivemind-bots:matrix.org",
+        bot_mention="thehivebot",
+        key="your-access-key",
+        password="your-password",
+        host="ws://192.168.1.100",
+        port=5678,
+        response_timeout=30.0,
+    )
+    await bridge.start()
+    try:
+        await asyncio.Event().wait()  # run until cancelled
+    finally:
+        await bridge.stop()
+
+asyncio.run(main())
+```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,86 @@
+# Setup Walkthrough
+
+This walkthrough takes you from nothing to a working Matrix chatbot backed by a HiveMind hub.
+
+## How the bridge fits together
+
+The bridge is a HiveMind satellite. It holds two connections at once:
+
+- **To Matrix** — it logs in with a bot access token, joins a room, and listens for messages.
+- **To the HiveMind hub** — it authenticates with a HiveMind access key and password, then exchanges encrypted protocol messages.
+
+When a room message mentions the bot, the bridge sends a `recognizer_loop:utterance` to the hub and waits for a `speak` reply, which it posts back to the room.
+
+```
+Matrix room  ⇄  bridge  ⇄  hivemind-core hub  ⇄  OVOS pipeline / skills
+```
+
+## Step 1 — Stand up a HiveMind hub
+
+Install and run [hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core) on a machine reachable from the bridge:
+
+```bash
+pip install hivemind-core
+hivemind-core listen
+```
+
+By default the hub listens on port `5678`.
+
+## Step 2 — Register the bridge as a client
+
+On the hub machine, issue credentials for the bridge:
+
+```bash
+hivemind-core add-client --name matrix-bridge \
+  --access-key "your-access-key" --password "your-password"
+```
+
+Keep the access key and password; the bridge authenticates with them. List existing clients with `hivemind-core list-clients`.
+
+## Step 3 — Create a Matrix bot account
+
+1. Register a Matrix account for the bot on any homeserver (`matrix.org` or self-hosted).
+2. Log in once with a client such as [Element](https://element.io).
+3. Copy the account's **access token** (Element: *Settings → Help & About → Access Token*).
+4. Create or pick a room, note its alias (for example `#hivemind-bots:matrix.org`), and invite the bot account into it.
+
+## Step 4 — Install the bridge
+
+```bash
+pip install git+https://github.com/JarbasHiveMind/HiveMind-matrix-bridge
+```
+
+## Step 5 — Provide the HiveMind credentials
+
+Either store an identity once:
+
+```bash
+hivemind-client set-identity \
+  --key "your-access-key" \
+  --password "your-password" \
+  --host "ws://192.168.1.100"
+```
+
+or pass `--key/--password/--host` on each run.
+
+## Step 6 — Run
+
+```bash
+HiveMind-matrix run \
+  --botname thehivebot \
+  --matrixtoken "syt_your_access_token" \
+  --matrixhost "https://matrix.org" \
+  --room "#hivemind-bots:matrix.org"
+```
+
+You should see the bridge log `connected to Matrix` and `connected to HiveMind`.
+
+## Step 7 — Talk to it
+
+In the room, mention the bot:
+
+```
+thehivebot what is the weather?
+```
+
+The bridge forwards the text after the mention to the hub and posts the spoken answer back.


### PR DESCRIPTION
Brings the README and `docs/` to zero-to-hero quality.

## What this adds
- **README** — tagline, where the bridge sits (satellite relaying a Matrix room to a hivemind-core hub), prerequisites (Matrix bot token + room, HiveMind access key), install, quickstart (register client → set identity → run → message), configuration table, troubleshooting.
- **docs/setup.md** — end-to-end walkthrough from hub to first message.
- **docs/configuration.md** — Matrix + HiveMind credential reference, identity file, response timeout, encryption notes.
- **docs/examples.md** — stored-identity vs inline runs, a sample conversation, embedding `HiveMindMatrixBridge` programmatically.

Docs only — no code, version, or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)